### PR TITLE
Use private queue for all CoreData operations

### DIFF
--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.h
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.h
@@ -43,28 +43,9 @@
 	NSMutableDictionary *myJidCache;
 	
 	int32_t pendingRequests;
-	
-	NSManagedObjectModel *managedObjectModel;
-	NSPersistentStoreCoordinator *persistentStoreCoordinator;
+
 	NSManagedObjectContext *managedObjectContext;
 	NSManagedObjectContext *mainThreadManagedObjectContext;
-    
-    NSMutableArray *willSaveManagedObjectContextBlocks;
-    NSMutableArray *didSaveManagedObjectContextBlocks;
-	
-@protected
-	
-	NSString *databaseFileName;
-    NSDictionary *storeOptions;
-	NSUInteger saveThreshold;
-	NSUInteger saveCount;
-    
-    BOOL autoRemovePreviousDatabaseFile;
-    BOOL autoRecreateDatabaseFile;
-    BOOL autoAllowExternalBinaryDataStorage;
-	
-	dispatch_queue_t storageQueue;
-	void *storageQueueTag;
 }
 
 /**
@@ -104,7 +85,7 @@
  *
  * Default 500
 **/
-@property (readwrite) NSUInteger saveThreshold;
+@property (atomic, readwrite) NSUInteger saveThreshold;
 
 /**
  * Provides access to the the thread-safe components of the CoreData stack.
@@ -146,7 +127,7 @@
  * Default NO
 **/
 
-@property (readwrite) BOOL autoRemovePreviousDatabaseFile;
+@property (atomic, readwrite) BOOL autoRemovePreviousDatabaseFile;
 
 /**
  * The Database File is automatically recreated if the persistant store cannot read it e.g. the model changed or the file became corrupt.
@@ -154,7 +135,7 @@
  *
  * Default NO
 **/
-@property (readwrite) BOOL autoRecreateDatabaseFile;
+@property (atomic, readwrite) BOOL autoRecreateDatabaseFile;
 
 /**
  * This method calls setAllowsExternalBinaryDataStorage:YES for all Binary Data Attributes in the Managed Object Model.
@@ -162,6 +143,6 @@
  *
  * Default NO
 **/
-@property (readwrite) BOOL autoAllowExternalBinaryDataStorage;
+@property (atomic, readwrite) BOOL autoAllowExternalBinaryDataStorage;
 
 @end

--- a/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorage.m
@@ -22,41 +22,6 @@
 
 @implementation XMPPCoreDataStorage
 
-static NSMutableSet *databaseFileNames;
-
-+ (void)initialize
-{
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		
-		databaseFileNames = [[NSMutableSet alloc] init];
-	});
-}
-
-+ (BOOL)registerDatabaseFileName:(NSString *)dbFileName
-{
-	BOOL result = NO;
-	
-	@synchronized(databaseFileNames)
-	{
-		if (![databaseFileNames containsObject:dbFileName])
-		{
-			[databaseFileNames addObject:dbFileName];
-			result = YES;
-		}
-	}
-	
-	return result;
-}
-
-+ (void)unregisterDatabaseFileName:(NSString *)dbFileName
-{
-	@synchronized(databaseFileNames)
-	{
-		[databaseFileNames removeObject:dbFileName];
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Override Me
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -143,27 +108,27 @@ static NSMutableSet *databaseFileNames;
 			
     NSPersistentStore *persistentStore;
 	
-	if (storePath)
-	{
-		// SQLite persistent store
-		
-		NSURL *storeUrl = [NSURL fileURLWithPath:storePath];
-		
-		persistentStore = [persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType
-		                                                           configuration:nil
-		                                                                     URL:storeUrl
-		                                                                 options:storeOptions
-		                                                                   error:errorPtr];
-	}
-	else
-	{
-		// In-Memory persistent store
-		
-		persistentStore = [persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType
-		                                                           configuration:nil
-		                                                                     URL:nil
-		                                                                 options:nil
-		                                                                   error:errorPtr];
+    if (storePath)
+    {
+        // SQLite persistent store
+        
+        NSURL *storeUrl = [NSURL fileURLWithPath:storePath];
+        
+        persistentStore = [self.persistentStoreCoordinator addPersistentStoreWithType:NSSQLiteStoreType
+                                                                        configuration:nil
+                                                                                  URL:storeUrl
+                                                                              options:storeOptions
+                                                                                error:errorPtr];
+    }
+    else
+    {
+        // In-Memory persistent store
+        
+        persistentStore = [self.persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType
+                                                                        configuration:nil
+                                                                                  URL:nil
+                                                                              options:nil
+                                                                                error:errorPtr];
 	}
 	
     return persistentStore != nil;
@@ -237,22 +202,23 @@ static NSMutableSet *databaseFileNames;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @synthesize databaseFileName;
+@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
 @synthesize storeOptions;
+@synthesize saveThreshold;
+@synthesize autoRemovePreviousDatabaseFile;
+@synthesize autoRecreateDatabaseFile;
+@synthesize autoAllowExternalBinaryDataStorage;
+@synthesize managedObjectModel = _managedObjectModel;
 
 - (void)commonInit
 {
-	saveThreshold = 500;
-	
-	storageQueue = dispatch_queue_create(class_getName([self class]), NULL);
-	
-	storageQueueTag = &storageQueueTag;
-	dispatch_queue_set_specific(storageQueue, storageQueueTag, storageQueueTag, NULL);
+	self.saveThreshold = 500;
 	
 	myJidCache = [[NSMutableDictionary alloc] init];
-    
-    willSaveManagedObjectContextBlocks = [[NSMutableArray alloc] init];
-    didSaveManagedObjectContextBlocks = [[NSMutableArray alloc] init];
-	
+
+	[self setupManagedObjectModel];
+    [self setupPersistentStoreCoordinator];
+
 	[[NSNotificationCenter defaultCenter] addObserver:self
 	                                         selector:@selector(updateJidCache:)
 	                                             name:XMPPStreamDidChangeMyJIDNotification
@@ -278,13 +244,7 @@ static NSMutableSet *databaseFileNames;
         else
             storeOptions = [self defaultStoreOptions];
 		
-		if (![[self class] registerDatabaseFileName:databaseFileName])
-		{
-			return nil;
-		}
-		
 		[self commonInit];
-		NSAssert(storageQueue != NULL, @"Subclass forgot to invoke [super commonInit]");
 	}
 	return self;
 }
@@ -294,7 +254,6 @@ static NSMutableSet *databaseFileNames;
 	if ((self = [super init]))
 	{
 		[self commonInit];
-		NSAssert(storageQueue != NULL, @"Subclass forgot to invoke [super commonInit]");
 	}
 	return self;
 }
@@ -309,46 +268,120 @@ static NSMutableSet *databaseFileNames;
 	NSParameterAssert(aParent != nil);
 	NSParameterAssert(queue != NULL);
 	
-	if (queue == storageQueue)
-	{
-		// This class is designed to be run on a separate dispatch queue from its parent.
-		// This allows us to optimize the database save operations by buffering them,
-		// and executing them when demand on the storage instance is low.
-		
-		return NO;
-	}
-	
 	return YES;
 }
 
-- (NSUInteger)saveThreshold
-{
-	if (dispatch_get_specific(storageQueueTag))
-	{
-		return saveThreshold;
-	}
-	else
-	{
-		__block NSUInteger result;
-		
-		dispatch_sync(storageQueue, ^{
-			result = self->saveThreshold;
-		});
-		
-		return result;
-	}
+- (void)setupManagedObjectModel {
+    NSString *momName = [self managedObjectModelName];
+
+    XMPPLogVerbose(@"%@: Creating managedObjectModel (%@)", [self class], momName);
+
+    NSString *momPath = [[self managedObjectModelBundle] pathForResource:momName ofType:@"mom"];
+    if (momPath == nil)
+    {
+        // The model may be versioned or created with Xcode 4, try momd as an extension.
+        momPath = [[self managedObjectModelBundle] pathForResource:momName ofType:@"momd"];
+    }
+
+    if (momPath)
+    {
+        // If path is nil, then NSURL or NSManagedObjectModel will throw an exception
+
+        NSURL *momUrl = [NSURL fileURLWithPath:momPath];
+
+        _managedObjectModel = [[[NSManagedObjectModel alloc] initWithContentsOfURL:momUrl] copy];
+    }
+    else
+    {
+        XMPPLogWarn(@"%@: Couldn't find managedObjectModel file - %@", [self class], momName);
+    }
+
+    if(self.autoAllowExternalBinaryDataStorage)
+    {
+        NSArray *entities = [self.managedObjectModel entities];
+
+        for(NSEntityDescription *entity in entities)
+        {
+            NSDictionary *attributesByName = [entity attributesByName];
+
+            [attributesByName enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+
+                if([obj attributeType] == NSBinaryDataAttributeType)
+                {
+                    [obj setAllowsExternalBinaryDataStorage:YES];
+                }
+
+            }];
+        }
+
+    }
 }
 
-- (void)setSaveThreshold:(NSUInteger)newSaveThreshold
-{
-	dispatch_block_t block = ^{
-		self->saveThreshold = newSaveThreshold;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+- (void)setupPersistentStoreCoordinator {
+    NSManagedObjectModel *mom = [self managedObjectModel];
+    if (mom == nil)
+    {
+        return;
+    }
+
+    XMPPLogVerbose(@"%@: Creating persistentStoreCoordinator", [self class]);
+
+    _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:mom];
+
+    if (self.databaseFileName)
+    {
+        // SQLite persistent store
+
+        NSString *docsPath = [self persistentStoreDirectory];
+        NSString *storePath = [docsPath stringByAppendingPathComponent:self.databaseFileName];
+        if (storePath)
+        {
+            // If storePath is nil, then NSURL will throw an exception
+
+            if(self.autoRemovePreviousDatabaseFile)
+            {
+                if ([[NSFileManager defaultManager] fileExistsAtPath:storePath])
+                {
+                    [[NSFileManager defaultManager] removeItemAtPath:storePath error:nil];
+                }
+            }
+
+            [self willCreatePersistentStoreWithPath:storePath options:self.storeOptions];
+
+            NSError *error = nil;
+
+            BOOL didAddPersistentStore = [self addPersistentStoreWithPath:storePath options:self.storeOptions error:&error];
+
+            if(self->autoRecreateDatabaseFile && !didAddPersistentStore)
+            {
+                [[NSFileManager defaultManager] removeItemAtPath:storePath error:NULL];
+
+                didAddPersistentStore = [self addPersistentStoreWithPath:storePath options:self.storeOptions error:&error];
+            }
+
+            if (!didAddPersistentStore)
+            {
+                [self didNotAddPersistentStoreWithPath:storePath options:self.storeOptions error:error];
+            }
+        }
+        else
+        {
+            XMPPLogWarn(@"%@: Error creating persistentStoreCoordinator - Nil persistentStoreDirectory",
+                        [self class]);
+        }
+    }
+    else
+    {
+        // In-Memory persistent store
+
+        [self willCreatePersistentStoreWithPath:nil options:self->storeOptions];
+
+        NSError *error = nil;
+        if (![self addPersistentStoreWithPath:nil options:self->storeOptions error:&error])
+        {
+            [self didNotAddPersistentStoreWithPath:nil options:self->storeOptions error:error];
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -370,26 +403,23 @@ static NSMutableSet *databaseFileNames;
 	if (stream == nil) return nil;
 	
 	__block XMPPJID *result = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		NSNumber *key = [NSNumber xmpp_numberWithPtr:(__bridge void *)stream];
-		
-		result = (XMPPJID *) self->myJidCache[key];
-		if (!result)
-		{
-			result = [stream myJID];
-			if (result)
+
+	[self executeBlock:^{
+		@autoreleasepool {
+			NSNumber *key = [NSNumber xmpp_numberWithPtr:(__bridge void *)stream];
+
+			result = (XMPPJID *) self->myJidCache[key];
+			if (!result)
 			{
-				self->myJidCache[key] = result;
+				result = [stream myJID];
+				if (result)
+				{
+					self->myJidCache[key] = result;
+				}
 			}
 		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+	}];
+
 	
 	return result;
 }
@@ -407,36 +437,32 @@ static NSMutableSet *databaseFileNames;
 	// In this case, they are delivered on xmppStream's internal processing queue.
 	
 	XMPPStream *stream = (XMPPStream *)[notification object];
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		NSNumber *key = [NSNumber xmpp_numberWithPtr:(__bridge void *)stream];
-		XMPPJID *cachedJID = self->myJidCache[key];
-		
-		if (cachedJID)
-		{
-			XMPPJID *newJID = [stream myJID];
-			
-			if (newJID)
+
+	[self scheduleBlock:^{
+		@autoreleasepool {
+			NSNumber *key = [NSNumber xmpp_numberWithPtr:(__bridge void *)stream];
+			XMPPJID *cachedJID = self->myJidCache[key];
+
+			if (cachedJID)
 			{
-				if (![cachedJID isEqualToJID:newJID])
+				XMPPJID *newJID = [stream myJID];
+
+				if (newJID)
 				{
-					self->myJidCache[key] = newJID;
-					[self didChangeCachedMyJID:newJID forXMPPStream:stream];
+					if (![cachedJID isEqualToJID:newJID])
+					{
+						self->myJidCache[key] = newJID;
+						[self didChangeCachedMyJID:newJID forXMPPStream:stream];
+					}
+				}
+				else
+				{
+					[self->myJidCache removeObjectForKey:key];
+					[self didChangeCachedMyJID:nil forXMPPStream:stream];
 				}
 			}
-			else
-			{
-				[self->myJidCache removeObjectForKey:key];
-				[self didChangeCachedMyJID:nil forXMPPStream:stream];
-			}
 		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+	}];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -468,172 +494,6 @@ static NSMutableSet *databaseFileNames;
     return persistentStoreDirectory;
 }
 
-- (NSManagedObjectModel *)managedObjectModel
-{
-	// This is a public method.
-	// It may be invoked on any thread/queue.
-	
-	__block NSManagedObjectModel *result = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		if (self->managedObjectModel)
-		{
-			result = self->managedObjectModel;
-			return;
-		}
-		        
-		NSString *momName = [self managedObjectModelName];
-		
-		XMPPLogVerbose(@"%@: Creating managedObjectModel (%@)", [self class], momName);
-		
-		NSString *momPath = [[self managedObjectModelBundle] pathForResource:momName ofType:@"mom"];
-		if (momPath == nil)
-		{
-			// The model may be versioned or created with Xcode 4, try momd as an extension.
-			momPath = [[self managedObjectModelBundle] pathForResource:momName ofType:@"momd"];
-		}
-    
-		if (momPath)
-		{
-			// If path is nil, then NSURL or NSManagedObjectModel will throw an exception
-			
-			NSURL *momUrl = [NSURL fileURLWithPath:momPath];
-			
-			self->managedObjectModel = [[[NSManagedObjectModel alloc] initWithContentsOfURL:momUrl] copy];
-		}
-		else
-		{
-			XMPPLogWarn(@"%@: Couldn't find managedObjectModel file - %@", [self class], momName);
-		}
-        
-		if([NSAttributeDescription instancesRespondToSelector:@selector(setAllowsExternalBinaryDataStorage:)])
-		{
-			if(self->autoAllowExternalBinaryDataStorage)
-			{
-				NSArray *entities = [self->managedObjectModel entities];
-
-				for(NSEntityDescription *entity in entities)
-				{
-					NSDictionary *attributesByName = [entity attributesByName];
-
-					[attributesByName enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-
-						if([obj attributeType] == NSBinaryDataAttributeType)
-						{
-							[obj setAllowsExternalBinaryDataStorage:YES];
-						}
-
-					}];
-				}
-
-			}
-            
-        }
-		
-		result = self->managedObjectModel;
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-	
-	return result;
-}
-
-- (NSPersistentStoreCoordinator *)persistentStoreCoordinator
-{
-	// This is a public method.
-	// It may be invoked on any thread/queue.
-	
-	__block NSPersistentStoreCoordinator *result = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		if (self->persistentStoreCoordinator)
-		{
-			result = self->persistentStoreCoordinator;
-			return;
-		}
-		
-		NSManagedObjectModel *mom = [self managedObjectModel];
-		if (mom == nil)
-		{
-			return;
-		}
-		
-		XMPPLogVerbose(@"%@: Creating persistentStoreCoordinator", [self class]);
-		
-		self->persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:mom];
-		
-		if (self->databaseFileName)
-		{
-			// SQLite persistent store
-			
-			NSString *docsPath = [self persistentStoreDirectory];
-			NSString *storePath = [docsPath stringByAppendingPathComponent:self->databaseFileName];
-			if (storePath)
-			{
-				// If storePath is nil, then NSURL will throw an exception
-
-				if(self->autoRemovePreviousDatabaseFile)
-				{
-					if ([[NSFileManager defaultManager] fileExistsAtPath:storePath])
-					{
-						[[NSFileManager defaultManager] removeItemAtPath:storePath error:nil];
-					}
-				}
-				
-				[self willCreatePersistentStoreWithPath:storePath options:self->storeOptions];
-				
-				NSError *error = nil;
-				
-				BOOL didAddPersistentStore = [self addPersistentStoreWithPath:storePath options:self->storeOptions error:&error];
-				
-				if(self->autoRecreateDatabaseFile && !didAddPersistentStore)
-				{
-					[[NSFileManager defaultManager] removeItemAtPath:storePath error:NULL];
-					
-					didAddPersistentStore = [self addPersistentStoreWithPath:storePath options:self->storeOptions error:&error];
-				}
-				
-				if (!didAddPersistentStore)
-				{
-					[self didNotAddPersistentStoreWithPath:storePath options:self->storeOptions error:error];
-				}
-			}
-			else
-			{
-				XMPPLogWarn(@"%@: Error creating persistentStoreCoordinator - Nil persistentStoreDirectory",
-							[self class]);
-			}
-		}
-		else
-		{
-			// In-Memory persistent store
-			
-			[self willCreatePersistentStoreWithPath:nil options:self->storeOptions];
-			
-			NSError *error = nil;
-			if (![self addPersistentStoreWithPath:nil options:self->storeOptions error:&error])
-			{
-				[self didNotAddPersistentStoreWithPath:nil options:self->storeOptions error:error];
-			}
-		}
-		
-		result = self->persistentStoreCoordinator;
-		
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-
-    return result;
-}
-
 - (NSManagedObjectContext *)managedObjectContext
 {
 	// This is a private method.
@@ -652,7 +512,7 @@ static NSMutableSet *databaseFileNames;
 	// then you need to go read the documentation for core data,
 	// specifically the section entitled "Concurrency with Core Data".
 	// 
-	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	// 
 	// Do NOT remove the assert statment above!
 	// Read the comments above!
@@ -713,28 +573,15 @@ static NSMutableSet *databaseFileNames;
 	{
 		XMPPLogVerbose(@"%@: Creating mainThreadManagedObjectContext", [self class]);
 		
-		if ([NSManagedObjectContext instancesRespondToSelector:@selector(initWithConcurrencyType:)])
-			mainThreadManagedObjectContext =
-			    [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-		else
-			mainThreadManagedObjectContext = [[NSManagedObjectContext alloc] init];
-		
-		if (dispatch_get_specific(storageQueueTag))
-        {
-            mainThreadManagedObjectContext.parentContext = [self managedObjectContext];
-        }
-        else
-        {
-            dispatch_sync(storageQueue, ^{
-                mainThreadManagedObjectContext.parentContext = [self managedObjectContext];
-            });
-        }
+
+		mainThreadManagedObjectContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+		mainThreadManagedObjectContext.parentContext = [self managedObjectContext];
 		mainThreadManagedObjectContext.undoManager = nil;
 		
-		[[NSNotificationCenter defaultCenter] addObserver:self
-		                                         selector:@selector(managedObjectContextDidSave:)
-		                                             name:NSManagedObjectContextDidSaveNotification
-		                                           object:nil];
+//		[[NSNotificationCenter defaultCenter] addObserver:self
+//		                                         selector:@selector(managedObjectContextDidSave:)
+//		                                             name:NSManagedObjectContextDidSaveNotification
+//		                                           object:nil];
 		
 		// Todo: If we knew that our private managedObjectContext was going to be the only one writing to the database,
 		// then a small optimization would be to use it as the object when registering above.
@@ -743,111 +590,27 @@ static NSMutableSet *databaseFileNames;
 	return mainThreadManagedObjectContext;
 }
 
-- (void)managedObjectContextDidSave:(NSNotification *)notification
-{
-	NSManagedObjectContext *sender = (NSManagedObjectContext *)[notification object];
-	
-	if ((sender != mainThreadManagedObjectContext) &&
-	    (sender.persistentStoreCoordinator == mainThreadManagedObjectContext.persistentStoreCoordinator))
-	{
-		XMPPLogVerbose(@"%@: %@ - Merging changes into mainThreadManagedObjectContext", THIS_FILE, THIS_METHOD);
-		
-		dispatch_async(dispatch_get_main_queue(), ^{
-            
-            // http://stackoverflow.com/questions/3923826/nsfetchedresultscontroller-with-predicate-ignores-changes-merged-from-different
-			for (NSManagedObject *object in [notification userInfo][NSUpdatedObjectsKey]) {
-				[[self->mainThreadManagedObjectContext objectWithID:[object objectID]] willAccessValueForKey:nil];
-			}
-			
-			[self->mainThreadManagedObjectContext mergeChangesFromContextDidSaveNotification:notification];
-			[self mainThreadManagedObjectContextDidMergeChanges];
-		});
-    }
-}
-
-- (BOOL)autoRemovePreviousDatabaseFile
-{
-	__block BOOL result = NO;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		result = self->autoRemovePreviousDatabaseFile;
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-	
-	return result;
-}
-
-- (void)setAutoRemovePreviousDatabaseFile:(BOOL)flag
-{
-	dispatch_block_t block = ^{
-		self->autoRemovePreviousDatabaseFile = flag;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-}
-
-- (BOOL)autoRecreateDatabaseFile
-{
-	__block BOOL result = NO;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		result = self->autoRecreateDatabaseFile;
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-	
-	return result;
-}
-
-- (void)setAutoRecreateDatabaseFile:(BOOL)flag
-{
-	dispatch_block_t block = ^{
-		self->autoRecreateDatabaseFile = flag;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-}
-
-- (BOOL)autoAllowExternalBinaryDataStorage
-{
-	__block BOOL result = NO;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		result = self->autoAllowExternalBinaryDataStorage;
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-	
-	return result;
-}
-
-- (void)setAutoAllowExternalBinaryDataStorage:(BOOL)flag
-{
-	dispatch_block_t block = ^{
-		self->autoAllowExternalBinaryDataStorage = flag;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);	
-}
+//- (void)managedObjectContextDidSave:(NSNotification *)notification
+//{
+//	NSManagedObjectContext *sender = (NSManagedObjectContext *)[notification object];
+//	
+//	if ((sender != mainThreadManagedObjectContext) &&
+//	    (sender.persistentStoreCoordinator == mainThreadManagedObjectContext.persistentStoreCoordinator))
+//	{
+//		XMPPLogVerbose(@"%@: %@ - Merging changes into mainThreadManagedObjectContext", THIS_FILE, THIS_METHOD);
+//		
+//		dispatch_async(dispatch_get_main_queue(), ^{
+//            
+//            // http://stackoverflow.com/questions/3923826/nsfetchedresultscontroller-with-predicate-ignores-changes-merged-from-different
+//			for (NSManagedObject *object in [notification userInfo][NSUpdatedObjectsKey]) {
+//				[[self.mainThreadManagedObjectContext objectWithID:[object objectID]] willAccessValueForKey:nil];
+//			}
+//			
+//			[self.mainThreadManagedObjectContext mergeChangesFromContextDidSaveNotification:notification];
+//			[self mainThreadManagedObjectContextDidMergeChanges];
+//		});
+//    }
+//}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Utilities
@@ -872,36 +635,18 @@ static NSMutableSet *databaseFileNames;
 	// So there's no need for us to do it here, especially since this method is usually
 	// called from maybeSave below, which already does this check.
     
-    for(void (^block)(void) in willSaveManagedObjectContextBlocks) {
-        block();
-    }
-    
-    [willSaveManagedObjectContextBlocks removeAllObjects];
-    
 	NSError *error = nil;
-	if ([[self managedObjectContext] save:&error])
-	{
-		saveCount++;
-        
-        for(void (^block)(void) in didSaveManagedObjectContextBlocks) {
-            block();
-        }
-        
-        [didSaveManagedObjectContextBlocks removeAllObjects];
-	}
-	else
+	if (![[self managedObjectContext] save:&error])
 	{
 		XMPPLogWarn(@"%@: Error saving - %@ %@", [self class], error, [error userInfo]);
 		
 		[[self managedObjectContext] rollback];
-        
-        [didSaveManagedObjectContextBlocks removeAllObjects];
 	}
 }
 
 - (void)maybeSave:(int32_t)currentPendingRequests
 {
-	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	
 	
 	if ([[self managedObjectContext] hasChanges])
@@ -939,7 +684,7 @@ static NSMutableSet *databaseFileNames;
 	// If you remove the assert statement below, you are destroying the sole purpose for this class,
 	// which is to optimize the disk IO by buffering save operations.
 	// 
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	// 
 	// For a full discussion of this method, please see XMPPCoreDataStorageProtocol.h
 	//
@@ -947,19 +692,11 @@ static NSMutableSet *databaseFileNames;
 	//          ^
 	
 	OSAtomicIncrement32(&pendingRequests);
-	dispatch_sync(storageQueue, ^{ @autoreleasepool {
-		
+
+	[[self managedObjectContext] performBlockAndWait:^{
 		block();
-		
-		// Since this is a synchronous request, we want to return as quickly as possible.
-		// So we delay the maybeSave operation til later.
-		
-		dispatch_async(self->storageQueue, ^{ @autoreleasepool {
-			
-			[self maybeSave:OSAtomicDecrement32(&self->pendingRequests)];
-		}});
-		
-	}});
+		[self maybeSave:OSAtomicDecrement32(&self->pendingRequests)];
+	}];
 }
 
 - (void)scheduleBlock:(dispatch_block_t)block
@@ -969,7 +706,7 @@ static NSMutableSet *databaseFileNames;
 	// If you remove the assert statement below, you are destroying the sole purpose for this class,
 	// which is to optimize the disk IO by buffering save operations.
 	// 
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	// 
 	// For a full discussion of this method, please see XMPPCoreDataStorageProtocol.h
 	// 
@@ -977,35 +714,11 @@ static NSMutableSet *databaseFileNames;
 	//          ^
 	
 	OSAtomicIncrement32(&pendingRequests);
-	dispatch_async(storageQueue, ^{ @autoreleasepool {
-		
+
+	[[self managedObjectContext] performBlock:^{
 		block();
 		[self maybeSave:OSAtomicDecrement32(&self->pendingRequests)];
-	}});
-}
-
-- (void)addWillSaveManagedObjectContextBlock:(void (^)(void))willSaveBlock
-{
-    dispatch_block_t block = ^{
-		[self->willSaveManagedObjectContextBlocks addObject:[willSaveBlock copy]];
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
-}
-
-- (void)addDidSaveManagedObjectContextBlock:(void (^)(void))didSaveBlock
-{
-    dispatch_block_t block = ^{
-		[self->didSaveManagedObjectContextBlocks addObject:[didSaveBlock copy]];
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+	}];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1015,11 +728,6 @@ static NSMutableSet *databaseFileNames;
 - (void)dealloc
 {
 	[[NSNotificationCenter defaultCenter] removeObserver:self];
-	
-	if (databaseFileName)
-	{
-		[[self class] unregisterDatabaseFileName:databaseFileName];
-	}
 	
 	#if !OS_OBJECT_USE_OBJC
 	if (storageQueue)

--- a/Extensions/CoreDataStorage/XMPPCoreDataStorageProtected.h
+++ b/Extensions/CoreDataStorage/XMPPCoreDataStorageProtected.h
@@ -315,20 +315,4 @@
 **/
 - (void)scheduleBlock:(dispatch_block_t)block;
 
-/**
- * Sometimes you want to call a method before calling save on a Managed Object Context e.g. willSaveObject:
- *
- * addWillSaveManagedObjectContextBlock allows you to add a block of code to be called before saving a Managed Object Context,
- * without the overhead of having to call save at that moment.
-**/
-- (void)addWillSaveManagedObjectContextBlock:(void (^)(void))willSaveBlock;
-
-/**
- * Sometimes you want to call a method after calling save on a Managed Object Context e.g. didSaveObject:
- *
- * addDidSaveManagedObjectContextBlock allows you to add a block of code to be after saving a Managed Object Context,
- * without the overhead of having to call save at that moment.
-**/
-- (void)addDidSaveManagedObjectContextBlock:(void (^)(void))didSaveBlock;
-
 @end

--- a/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
+++ b/Extensions/Roster/CoreDataStorage/XMPPRosterCoreDataStorage.m
@@ -19,9 +19,6 @@
   static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 #endif
 
-#define AssertPrivateQueue() \
-        NSAssert(dispatch_get_specific(storageQueueTag), @"Private method: MUST run on storageQueue");
-
 
 @implementation XMPPRosterCoreDataStorage
 
@@ -48,8 +45,8 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 	[super commonInit];
 	
 	// This method is invoked by all public init methods of the superclass
-    autoRemovePreviousDatabaseFile = YES;
-	autoRecreateDatabaseFile = YES;
+    self.autoRemovePreviousDatabaseFile = YES;
+	self.autoRecreateDatabaseFile = YES;
     
 	rosterPopulationSet = [[NSMutableSet alloc] init];
 }
@@ -94,8 +91,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 - (void)_clearAllResourcesForXMPPStream:(XMPPStream *)stream
 {
 	XMPPLogTrace();
-	AssertPrivateQueue();
-	
+
 	NSManagedObjectContext *moc = [self managedObjectContext];
 	
 	NSEntityDescription *entity = [NSEntityDescription entityForName:@"XMPPResourceCoreDataStorageObject"
@@ -103,7 +99,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 	
 	NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 	[fetchRequest setEntity:entity];
-	[fetchRequest setFetchBatchSize:saveThreshold];
+	[fetchRequest setFetchBatchSize:self.saveThreshold];
 	
 	if (stream)
 	{
@@ -124,7 +120,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 		[moc deleteObject:resource];
         [user recalculatePrimaryResource];
         
-		if (++unsavedCount >= saveThreshold)
+		if (++unsavedCount >= self.saveThreshold)
 		{
 			[self save];
 			unsavedCount = 0;
@@ -280,7 +276,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 		
 		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 		[fetchRequest setEntity:entity];
-		[fetchRequest setFetchBatchSize:self->saveThreshold];
+		[fetchRequest setFetchBatchSize:self.saveThreshold];
 		
 		if (stream)
 		{
@@ -457,7 +453,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 		
 		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 		[fetchRequest setEntity:entity];
-		[fetchRequest setFetchBatchSize:self->saveThreshold];
+		[fetchRequest setFetchBatchSize:self.saveThreshold];
 		
 		if (stream)
 		{
@@ -476,7 +472,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 		{
 			[moc deleteObject:user];
 			
-			if (++unsavedCount >= self->saveThreshold)
+			if (++unsavedCount >= self.saveThreshold)
 			{
 				[self save];
 				unsavedCount = 0;
@@ -502,7 +498,7 @@ static XMPPRosterCoreDataStorage *sharedInstance;
 		
 		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 		[fetchRequest setEntity:entity];
-		[fetchRequest setFetchBatchSize:self->saveThreshold];
+		[fetchRequest setFetchBatchSize:self.saveThreshold];
 		
 		if (stream)
 		{

--- a/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
+++ b/Extensions/XEP-0045/CoreDataStorage/XMPPRoomCoreDataStorage.m
@@ -14,8 +14,8 @@
   static const int xmppLogLevel = XMPP_LOG_LEVEL_WARN;
 #endif
 
-#define AssertPrivateQueue() \
-            NSAssert(dispatch_get_specific(storageQueueTag), @"Private method: MUST run on storageQueue");
+//#define AssertPrivateQueue() \
+//            NSAssert(dispatch_get_specific(storageQueueTag), @"Private method: MUST run on storageQueue");
 
 @interface XMPPRoomCoreDataStorage ()
 {
@@ -100,70 +100,70 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 {
 	__block NSString *result = nil;
 	
-	dispatch_block_t block = ^{
-		result = self->messageEntityName;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->messageEntityName;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
 
 - (void)setMessageEntityName:(NSString *)newMessageEntityName
 {
-	dispatch_block_t block = ^{
-		self->messageEntityName = newMessageEntityName;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		self->messageEntityName = newMessageEntityName;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 - (NSString *)occupantEntityName
 {
 	__block NSString *result = nil;
 	
-	dispatch_block_t block = ^{
-		result = self->occupantEntityName;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->occupantEntityName;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
 
 - (void)setOccupantEntityName:(NSString *)newOccupantEntityName
 {
-	dispatch_block_t block = ^{
-		self->occupantEntityName = newOccupantEntityName;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		self->occupantEntityName = newOccupantEntityName;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 - (NSTimeInterval)maxMessageAge
 {
 	__block NSTimeInterval result = 0;
 	
-	dispatch_block_t block = ^{
-		result = self->maxMessageAge;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->maxMessageAge;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
@@ -227,25 +227,22 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 				[self createAndStartDeleteTimer];
 		}
 	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+
+	[self scheduleBlock:block];
 }
 
 - (NSTimeInterval)deleteInterval
 {
 	__block NSTimeInterval result = 0;
 	
-	dispatch_block_t block = ^{
-		result = self->deleteInterval;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->deleteInterval;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
@@ -298,38 +295,23 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 			[self destroyDeleteTimer];
 		}
 	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+
+	[self scheduleBlock:block];
 }
 
 - (void)pauseOldMessageDeletionForRoom:(XMPPJID *)roomJID
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
+	[self scheduleBlock:^{
 		[self->pausedMessageDeletion addObject:[roomJID bareJID]];
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+	}];
 }
 
 - (void)resumeOldMessageDeletionForRoom:(XMPPJID *)roomJID
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
+	[self scheduleBlock:^{
 		[self->pausedMessageDeletion removeObject:[roomJID bareJID]];
 		[self performDelete];
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+	}];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -370,7 +352,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 	NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 	[fetchRequest setEntity:messageEntity];
 	[fetchRequest setPredicate:predicate];
-	[fetchRequest setFetchBatchSize:saveThreshold];
+	[fetchRequest setFetchBatchSize:self.saveThreshold];
 	
 	NSError *error = nil;
 	NSArray *oldMessages = [moc executeFetchRequest:fetchRequest error:&error];
@@ -386,7 +368,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 	{
 		[moc deleteObject:oldMessage];
 		
-		if (++unsavedCount >= saveThreshold)
+		if (++unsavedCount >= self.saveThreshold)
 		{
 			[self save];
 			unsavedCount = 0;
@@ -426,36 +408,36 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 
 - (void)createAndStartDeleteTimer
 {
-	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxMessageAge > 0.0))
-	{
-		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, storageQueue);
-		
-		dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
-			
-			[self performDelete];
-			
-		}});
-		
-		[self updateDeleteTimer];
-		
-		if(deleteTimer != NULL)
-		{
-			dispatch_resume(deleteTimer);
-		}
-	}
+//	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxMessageAge > 0.0))
+//	{
+//		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, storageQueue);
+//
+//		dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
+//
+//			[self performDelete];
+//
+//		}});
+//
+//		[self updateDeleteTimer];
+//
+//		if(deleteTimer != NULL)
+//		{
+//			dispatch_resume(deleteTimer);
+//		}
+//	}
 }
 
 - (void)clearAllOccupantsFromRoom:(XMPPJID *)roomJID
 {
 	XMPPLogTrace();
-	AssertPrivateQueue();
+//	AssertPrivateQueue();
 	
 	NSManagedObjectContext *moc = [self managedObjectContext];
 	NSEntityDescription *entity = [self occupantEntity:moc];
 	
 	NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 	[fetchRequest setEntity:entity];
-	[fetchRequest setFetchBatchSize:saveThreshold];
+	[fetchRequest setFetchBatchSize:self.saveThreshold];
 	
 	if (roomJID)
 	{
@@ -473,7 +455,7 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 	{
 		[moc deleteObject:occupant];
 		
-		if (++unsavedCount >= saveThreshold)
+		if (++unsavedCount >= self.saveThreshold)
 		{
 			[self save];
 			unsavedCount = 0;
@@ -806,51 +788,51 @@ static XMPPRoomCoreDataStorage *sharedInstance;
 	
 	__block NSDate *result = nil;
 	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		NSManagedObjectContext *moc = inMoc ? : [self managedObjectContext];
-		
-		NSEntityDescription *entity = [self messageEntity:moc];
-		
-		NSPredicate *predicate;
-		if (xmppStream)
-		{
-			NSString *streamBareJidStr = [[self myJIDForXMPPStream:xmppStream] bare];
-			
-			NSString *predicateFormat = @"roomJIDStr == %@ AND streamBareJidStr == %@";
-			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID.bare, streamBareJidStr];
-		}
-		else
-		{
-			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID.bare];
-		}
-		
-		NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:NO];
-		NSArray *sortDescriptors = @[sortDescriptor];
-		
-		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-		[fetchRequest setEntity:entity];
-		[fetchRequest setPredicate:predicate];
-		[fetchRequest setSortDescriptors:sortDescriptors];
-		[fetchRequest setFetchLimit:1];
-		
-		NSError *error = nil;
-		XMPPRoomMessageCoreDataStorageObject *message = [[moc executeFetchRequest:fetchRequest error:&error] lastObject];
-
-		if (error)
-		{
-			XMPPLogError(@"%@: %@ - fetchRequest error: %@", THIS_FILE, THIS_METHOD, error);
-		}
-		else
-		{
-			result = [message.localTimestamp copy];
-		}
-	}};
-	
-	if (inMoc == nil)
-		dispatch_sync(storageQueue, block);
-	else
-		block();
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//		
+//		NSManagedObjectContext *moc = inMoc ? : [self managedObjectContext];
+//		
+//		NSEntityDescription *entity = [self messageEntity:moc];
+//		
+//		NSPredicate *predicate;
+//		if (xmppStream)
+//		{
+//			NSString *streamBareJidStr = [[self myJIDForXMPPStream:xmppStream] bare];
+//			
+//			NSString *predicateFormat = @"roomJIDStr == %@ AND streamBareJidStr == %@";
+//			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID.bare, streamBareJidStr];
+//		}
+//		else
+//		{
+//			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID.bare];
+//		}
+//		
+//		NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:NO];
+//		NSArray *sortDescriptors = @[sortDescriptor];
+//		
+//		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+//		[fetchRequest setEntity:entity];
+//		[fetchRequest setPredicate:predicate];
+//		[fetchRequest setSortDescriptors:sortDescriptors];
+//		[fetchRequest setFetchLimit:1];
+//		
+//		NSError *error = nil;
+//		XMPPRoomMessageCoreDataStorageObject *message = [[moc executeFetchRequest:fetchRequest error:&error] lastObject];
+//
+//		if (error)
+//		{
+//			XMPPLogError(@"%@: %@ - fetchRequest error: %@", THIS_FILE, THIS_METHOD, error);
+//		}
+//		else
+//		{
+//			result = [message.localTimestamp copy];
+//		}
+//	}};
+//	
+//	if (inMoc == nil)
+//		dispatch_sync(storageQueue, block);
+//	else
+//		block();
 	
 	return result;
 }

--- a/Extensions/XEP-0045/HybridStorage/XMPPRoomHybridStorage.m
+++ b/Extensions/XEP-0045/HybridStorage/XMPPRoomHybridStorage.m
@@ -79,7 +79,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 	
 	pausedMessageDeletion = [[NSMutableSet alloc] init];
 	
-	autoRecreateDatabaseFile = YES;
+	self.autoRecreateDatabaseFile = YES;
 }
 
 /**
@@ -121,180 +121,180 @@ static XMPPRoomHybridStorage *sharedInstance;
 {
 	__block NSTimeInterval result = 0;
 	
-	dispatch_block_t block = ^{
-		result = self->maxMessageAge;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->maxMessageAge;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
 
 - (void)setMaxMessageAge:(NSTimeInterval)age
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		NSTimeInterval oldMaxMessageAge = self->maxMessageAge;
-		NSTimeInterval newMaxMessageAge = age;
-		
-		self->maxMessageAge = age;
-		
-		// There are several cases we need to handle here.
-		// 
-		// 1. If the maxAge was previously enabled and it just got disabled,
-		//    then we need to stop the deleteTimer. (And we might as well release it.)
-		// 
-		// 2. If the maxAge was previously disabled and it just got enabled,
-		//    then we need to setup the deleteTimer. (Plus we might need to do an immediate delete.)
-		// 
-		// 3. If the maxAge was increased,
-		//    then we don't need to do anything.
-		// 
-		// 4. If the maxAge was decreased,
-		//    then we should do an immediate delete.
-		
-		BOOL shouldDeleteNow = NO;
-		
-		if (oldMaxMessageAge > 0.0)
-		{
-			if (newMaxMessageAge <= 0.0)
-			{
-				// Handles #1
-				[self destroyDeleteTimer];
-			}
-			else if (oldMaxMessageAge > newMaxMessageAge)
-			{
-				// Handles #4
-				shouldDeleteNow = YES;
-			}
-			else
-			{
-				// Handles #3
-				// Nothing to do now
-			}
-		}
-		else if (newMaxMessageAge > 0.0)
-		{
-			// Handles #2
-			shouldDeleteNow = YES;
-		}
-		
-		if (shouldDeleteNow)
-		{
-			[self performDelete];
-			
-			if (self->deleteTimer)
-				[self updateDeleteTimer];
-			else
-				[self createAndStartDeleteTimer];
-		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//
+//		NSTimeInterval oldMaxMessageAge = self->maxMessageAge;
+//		NSTimeInterval newMaxMessageAge = age;
+//
+//		self->maxMessageAge = age;
+//
+//		// There are several cases we need to handle here.
+//		//
+//		// 1. If the maxAge was previously enabled and it just got disabled,
+//		//    then we need to stop the deleteTimer. (And we might as well release it.)
+//		//
+//		// 2. If the maxAge was previously disabled and it just got enabled,
+//		//    then we need to setup the deleteTimer. (Plus we might need to do an immediate delete.)
+//		//
+//		// 3. If the maxAge was increased,
+//		//    then we don't need to do anything.
+//		//
+//		// 4. If the maxAge was decreased,
+//		//    then we should do an immediate delete.
+//
+//		BOOL shouldDeleteNow = NO;
+//
+//		if (oldMaxMessageAge > 0.0)
+//		{
+//			if (newMaxMessageAge <= 0.0)
+//			{
+//				// Handles #1
+//				[self destroyDeleteTimer];
+//			}
+//			else if (oldMaxMessageAge > newMaxMessageAge)
+//			{
+//				// Handles #4
+//				shouldDeleteNow = YES;
+//			}
+//			else
+//			{
+//				// Handles #3
+//				// Nothing to do now
+//			}
+//		}
+//		else if (newMaxMessageAge > 0.0)
+//		{
+//			// Handles #2
+//			shouldDeleteNow = YES;
+//		}
+//
+//		if (shouldDeleteNow)
+//		{
+//			[self performDelete];
+//
+//			if (self->deleteTimer)
+//				[self updateDeleteTimer];
+//			else
+//				[self createAndStartDeleteTimer];
+//		}
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 - (NSTimeInterval)deleteInterval
 {
 	__block NSTimeInterval result = 0;
 	
-	dispatch_block_t block = ^{
-		result = self->deleteInterval;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->deleteInterval;
+//	};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }
 
 - (void)setDeleteInterval:(NSTimeInterval)interval
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		self->deleteInterval = interval;
-		
-		// There are several cases we need to handle here.
-		// 
-		// 1. If the deleteInterval was previously enabled and it just got disabled,
-		//    then we need to stop the deleteTimer. (And we might as well release it.)
-		// 
-		// 2. If the deleteInterval was previously disabled and it just got enabled,
-		//    then we need to setup the deleteTimer. (Plus we might need to do an immediate delete.)
-		// 
-		// 3. If the deleteInterval increased, then we need to reset the timer so that it fires at the later date.
-		// 
-		// 4. If the deleteInterval decreased, then we need to reset the timer so that it fires at an earlier date.
-		//    (Plus we might need to do an immediate delete.)
-		
-		if (self->deleteInterval > 0.0)
-		{
-			if (self->deleteTimer == NULL)
-			{
-				// Handles #2
-				// 
-				// Since the deleteTimer uses the lastDeleteTime to calculate it's first fireDate,
-				// if a delete is needed the timer will fire immediately.
-				
-				[self createAndStartDeleteTimer];
-			}
-			else
-			{
-				// Handles #3
-				// Handles #4
-				// 
-				// Since the deleteTimer uses the lastDeleteTime to calculate it's first fireDate,
-				// if a save is needed the timer will fire immediately.
-				
-				[self updateDeleteTimer];
-			}
-		}
-		else if (self->deleteTimer)
-		{
-			// Handles #1
-			
-			[self destroyDeleteTimer];
-		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//
+//		self->deleteInterval = interval;
+//
+//		// There are several cases we need to handle here.
+//		//
+//		// 1. If the deleteInterval was previously enabled and it just got disabled,
+//		//    then we need to stop the deleteTimer. (And we might as well release it.)
+//		//
+//		// 2. If the deleteInterval was previously disabled and it just got enabled,
+//		//    then we need to setup the deleteTimer. (Plus we might need to do an immediate delete.)
+//		//
+//		// 3. If the deleteInterval increased, then we need to reset the timer so that it fires at the later date.
+//		//
+//		// 4. If the deleteInterval decreased, then we need to reset the timer so that it fires at an earlier date.
+//		//    (Plus we might need to do an immediate delete.)
+//
+//		if (self->deleteInterval > 0.0)
+//		{
+//			if (self->deleteTimer == NULL)
+//			{
+//				// Handles #2
+//				//
+//				// Since the deleteTimer uses the lastDeleteTime to calculate it's first fireDate,
+//				// if a delete is needed the timer will fire immediately.
+//
+//				[self createAndStartDeleteTimer];
+//			}
+//			else
+//			{
+//				// Handles #3
+//				// Handles #4
+//				//
+//				// Since the deleteTimer uses the lastDeleteTime to calculate it's first fireDate,
+//				// if a save is needed the timer will fire immediately.
+//
+//				[self updateDeleteTimer];
+//			}
+//		}
+//		else if (self->deleteTimer)
+//		{
+//			// Handles #1
+//
+//			[self destroyDeleteTimer];
+//		}
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 - (void)pauseOldMessageDeletionForRoom:(XMPPJID *)roomJID
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		[self->pausedMessageDeletion addObject:[roomJID bareJID]];
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//
+//		[self->pausedMessageDeletion addObject:[roomJID bareJID]];
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 - (void)resumeOldMessageDeletionForRoom:(XMPPJID *)roomJID
 {
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		[self->pausedMessageDeletion removeObject:[roomJID bareJID]];
-		[self performDelete];
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_async(storageQueue, block);
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//
+//		[self->pausedMessageDeletion removeObject:[roomJID bareJID]];
+//		[self performDelete];
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_async(storageQueue, block);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -324,7 +324,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 	NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 	[fetchRequest setEntity:messageEntity];
 	[fetchRequest setPredicate:predicate];
-	[fetchRequest setFetchBatchSize:saveThreshold];
+	[fetchRequest setFetchBatchSize:self.saveThreshold];
 	
 	NSError *error = nil;
 	NSArray *oldMessages = [moc executeFetchRequest:fetchRequest error:&error];
@@ -340,7 +340,7 @@ static XMPPRoomHybridStorage *sharedInstance;
 	{
 		[moc deleteObject:oldMessage];
 		
-		if (++unsavedCount >= saveThreshold)
+		if (++unsavedCount >= self.saveThreshold)
 		{
 			[self save];
 			unsavedCount = 0;
@@ -380,21 +380,21 @@ static XMPPRoomHybridStorage *sharedInstance;
 
 - (void)createAndStartDeleteTimer
 {
-	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxMessageAge > 0.0))
-	{
-		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, storageQueue);
-		
-		dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
-			
-			[self performDelete];
-			
-		}});
-		
-		[self updateDeleteTimer];
-		
-		if (deleteTimer)
-			dispatch_resume(deleteTimer);
-	}
+//	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxMessageAge > 0.0))
+//	{
+//		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, storageQueue);
+//
+//		dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
+//
+//			[self performDelete];
+//
+//		}});
+//
+//		[self updateDeleteTimer];
+//
+//		if (deleteTimer)
+//			dispatch_resume(deleteTimer);
+//	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -690,58 +690,58 @@ static XMPPRoomHybridStorage *sharedInstance;
                                     inContext:(NSManagedObjectContext *)inMoc
 {
 	if (roomJID == nil) return nil;
-	
-	// It's possible to use our internal managedObjectContext only because we're not returning a NSManagedObject.
-	
-	__block NSDate *result = nil;
-	
-	dispatch_block_t block = ^{ @autoreleasepool {
-		
-		NSManagedObjectContext *moc = inMoc ? : [self managedObjectContext];
-		
-		NSEntityDescription *entity = [self messageEntity:moc];
-		
-		NSPredicate *predicate;
-		if (xmppStream)
-		{
-			NSString *streamBareJidStr = [[self myJIDForXMPPStream:xmppStream] bare];
-			
-			NSString *predicateFormat = @"roomJIDStr == %@ AND streamBareJidStr == %@";
-			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID, streamBareJidStr];
-		}
-		else
-		{
-			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID];
-		}
-		
-		NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:NO];
-		NSArray *sortDescriptors = @[sortDescriptor];
-		
-		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
-		[fetchRequest setEntity:entity];
-		[fetchRequest setPredicate:predicate];
-		[fetchRequest setSortDescriptors:sortDescriptors];
-		[fetchRequest setFetchLimit:1];
-		
-		NSError *error = nil;
-		XMPPRoomMessageHybridCoreDataStorageObject *message = (XMPPRoomMessageHybridCoreDataStorageObject *)
-		    [[moc executeFetchRequest:fetchRequest error:&error] lastObject];
 
-		if (error)
-		{
-			XMPPLogError(@"%@: %@ - fetchRequest error: %@", THIS_FILE, THIS_METHOD, error);
-		}
-		else
-		{
-			result = [message.localTimestamp copy];
-		}
-	}};
-	
-	if (inMoc == nil)
-		dispatch_sync(storageQueue, block);
-	else
-		block();
-	
+	// It's possible to use our internal managedObjectContext only because we're not returning a NSManagedObject.
+
+	__block NSDate *result = nil;
+
+//	dispatch_block_t block = ^{ @autoreleasepool {
+//
+//		NSManagedObjectContext *moc = inMoc ? : [self managedObjectContext];
+//
+//		NSEntityDescription *entity = [self messageEntity:moc];
+//
+//		NSPredicate *predicate;
+//		if (xmppStream)
+//		{
+//			NSString *streamBareJidStr = [[self myJIDForXMPPStream:xmppStream] bare];
+//
+//			NSString *predicateFormat = @"roomJIDStr == %@ AND streamBareJidStr == %@";
+//			predicate = [NSPredicate predicateWithFormat:predicateFormat, roomJID, streamBareJidStr];
+//		}
+//		else
+//		{
+//			predicate = [NSPredicate predicateWithFormat:@"roomJIDStr == %@", roomJID];
+//		}
+//
+//		NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"localTimestamp" ascending:NO];
+//		NSArray *sortDescriptors = @[sortDescriptor];
+//
+//		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
+//		[fetchRequest setEntity:entity];
+//		[fetchRequest setPredicate:predicate];
+//		[fetchRequest setSortDescriptors:sortDescriptors];
+//		[fetchRequest setFetchLimit:1];
+//
+//		NSError *error = nil;
+//		XMPPRoomMessageHybridCoreDataStorageObject *message = (XMPPRoomMessageHybridCoreDataStorageObject *)
+//		    [[moc executeFetchRequest:fetchRequest error:&error] lastObject];
+//
+//		if (error)
+//		{
+//			XMPPLogError(@"%@: %@ - fetchRequest error: %@", THIS_FILE, THIS_METHOD, error);
+//		}
+//		else
+//		{
+//			result = [message.localTimestamp copy];
+//		}
+//	}};
+//
+//	if (inMoc == nil)
+//		dispatch_sync(storageQueue, block);
+//	else
+//		block();
+//
 	return result;
 }
 
@@ -751,41 +751,41 @@ static XMPPRoomHybridStorage *sharedInstance;
 	
 	__block XMPPRoomOccupantHybridMemoryStorageObject *occupant = nil;
 	
-	void (^block)(BOOL) = ^(BOOL shouldCopy){ @autoreleasepool {
-		
-		XMPPJID *roomJid = [occupantJid bareJID];
-		
-		if (xmppStream)
-		{
-			XMPPJID *streamFullJid = [self myJIDForXMPPStream:xmppStream];
-			
-			NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
-			NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
-			
-			occupant = occupantsRoomDict[occupantJid];
-		}
-		else
-		{
-			for (XMPPJID *streamFullJid in self->occupantsGlobalDict)
-			{
-				NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
-				NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
-								
-				occupant = occupantsRoomDict[occupantJid];
-				if (occupant) break;
-			}
-		}
-		
-		if (shouldCopy)
-		{
-			occupant = [occupant copy];
-		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block(NO);
-	else
-		dispatch_sync(storageQueue, ^{ block(YES); });
+//	void (^block)(BOOL) = ^(BOOL shouldCopy){ @autoreleasepool {
+//
+//		XMPPJID *roomJid = [occupantJid bareJID];
+//
+//		if (xmppStream)
+//		{
+//			XMPPJID *streamFullJid = [self myJIDForXMPPStream:xmppStream];
+//
+//			NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
+//			NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
+//
+//			occupant = occupantsRoomDict[occupantJid];
+//		}
+//		else
+//		{
+//			for (XMPPJID *streamFullJid in self->occupantsGlobalDict)
+//			{
+//				NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
+//				NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
+//
+//				occupant = occupantsRoomDict[occupantJid];
+//				if (occupant) break;
+//			}
+//		}
+//
+//		if (shouldCopy)
+//		{
+//			occupant = [occupant copy];
+//		}
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block(NO);
+//	else
+//		dispatch_sync(storageQueue, ^{ block(YES); });
 	
 	return occupant;
 }
@@ -796,43 +796,43 @@ static XMPPRoomHybridStorage *sharedInstance;
 	
 	__block NSArray *results = @[];
 	
-	void (^block)(BOOL) = ^(BOOL shouldCopy){ @autoreleasepool {
-		
-		if (xmppStream)
-		{
-			XMPPJID *streamFullJid = [self myJIDForXMPPStream:xmppStream];
-			
-			NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
-			NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
-			
-			results = [occupantsRoomDict allValues];
-		}
-		else
-		{
-			for (XMPPJID *streamFullJid in self->occupantsGlobalDict)
-			{
-				NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
-				NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
-				
-				if (occupantsRoomDict)
-				{
-					results = [occupantsRoomDict allValues];
-					break;
-				}
-			}
-		}
-		
-		if (shouldCopy)
-		{
-			NSArray *temp = results;
-			results = [[NSArray alloc] initWithArray:temp copyItems:YES];
-		}
-	}};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block(NO);
-	else
-		dispatch_sync(storageQueue, ^{ block(YES); });
+//	void (^block)(BOOL) = ^(BOOL shouldCopy){ @autoreleasepool {
+//
+//		if (xmppStream)
+//		{
+//			XMPPJID *streamFullJid = [self myJIDForXMPPStream:xmppStream];
+//
+//			NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
+//			NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
+//
+//			results = [occupantsRoomDict allValues];
+//		}
+//		else
+//		{
+//			for (XMPPJID *streamFullJid in self->occupantsGlobalDict)
+//			{
+//				NSDictionary *occupantsRoomsDict = self->occupantsGlobalDict[streamFullJid];
+//				NSDictionary *occupantsRoomDict = occupantsRoomsDict[roomJid];
+//
+//				if (occupantsRoomDict)
+//				{
+//					results = [occupantsRoomDict allValues];
+//					break;
+//				}
+//			}
+//		}
+//
+//		if (shouldCopy)
+//		{
+//			NSArray *temp = results;
+//			results = [[NSArray alloc] initWithArray:temp copyItems:YES];
+//		}
+//	}};
+//
+//	if (dispatch_get_specific(storageQueueTag))
+//		block(NO);
+//	else
+//		dispatch_sync(storageQueue, ^{ block(YES); });
 	
 	return results;
 }

--- a/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorage.m
+++ b/Extensions/XEP-0054/CoreDataStorage/XMPPvCardCoreDataStorage.m
@@ -63,8 +63,8 @@ static XMPPvCardCoreDataStorage *sharedInstance;
 
 - (void)commonInit
 {
-    autoAllowExternalBinaryDataStorage = YES;
-    autoRecreateDatabaseFile = YES;
+    self.autoAllowExternalBinaryDataStorage = YES;
+    self.autoRecreateDatabaseFile = YES;
     [super commonInit];
 }
 

--- a/Extensions/XEP-0115/CoreDataStorage/XMPPCapabilitiesCoreDataStorage.m
+++ b/Extensions/XEP-0115/CoreDataStorage/XMPPCapabilitiesCoreDataStorage.m
@@ -36,7 +36,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 	XMPPLogTrace();
 	[super commonInit];
 
-	autoRecreateDatabaseFile = YES;
+	self.autoRecreateDatabaseFile = YES;
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark Setup
@@ -53,8 +53,6 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (XMPPCapsResourceCoreDataStorageObject *)resourceForJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
-	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
-	
 	XMPPLogTrace2(@"%@: %@ %@", THIS_FILE, THIS_METHOD, jid);
 	
 	if (jid == nil) return nil;
@@ -84,8 +82,6 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (XMPPCapsCoreDataStorageObject *)capsForHash:(NSString *)hash algorithm:(NSString *)hashAlg
 {
-	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
-	
 	XMPPLogTrace2(@"%@: capsForHash:%@ algorithm:%@", THIS_FILE, hash, hashAlg);
 	
 	if (hash == nil) return nil;
@@ -112,14 +108,12 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (void)_clearAllNonPersistentCapabilitiesForXMPPStream:(XMPPStream *)stream
 {
-	NSAssert(dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
-	
 	NSEntityDescription *entity = [NSEntityDescription entityForName:@"XMPPCapsResourceCoreDataStorageObject"
 	                                          inManagedObjectContext:[self managedObjectContext]];
 	
 	NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 	[fetchRequest setEntity:entity];
-	[fetchRequest setFetchBatchSize:saveThreshold];
+	[fetchRequest setFetchBatchSize:self.saveThreshold];
 	
 	if (stream)
 	{
@@ -151,7 +145,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 		
 		[[self managedObjectContext] deleteObject:resource];
 		
-		if (++unsavedCount >= saveThreshold)
+		if (++unsavedCount >= self.saveThreshold)
 		{
 			[self save];
 		}
@@ -198,9 +192,6 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 
 - (NSXMLElement *)capabilitiesForJID:(XMPPJID *)jid ext:(NSString **)extPtr xmppStream:(XMPPStream *)stream
 {
-	// By design this method should not be invoked from the storageQueue.
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
-	
 	XMPPLogTrace();
 	
 	__block NSXMLElement *result = nil;
@@ -310,7 +301,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
                  xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -390,7 +381,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
                   xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	
@@ -476,7 +467,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 		NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] init];
 		[fetchRequest setEntity:entity];
 		[fetchRequest setPredicate:predicate];
-		[fetchRequest setFetchBatchSize:self->saveThreshold];
+		[fetchRequest setFetchBatchSize:self.saveThreshold];
 		
 		NSArray *results = [[self managedObjectContext] executeFetchRequest:fetchRequest error:nil];
 		
@@ -486,7 +477,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 		{
 			resource.caps = caps;
 			
-			if (++unsavedCount >= self->saveThreshold)
+			if (++unsavedCount >= self.saveThreshold)
 			{
 				[self save];
 			}
@@ -498,7 +489,7 @@ static XMPPCapabilitiesCoreDataStorage *sharedInstance;
 - (void)setCapabilities:(NSXMLElement *)capabilities forJID:(XMPPJID *)jid xmppStream:(XMPPStream *)stream
 {
 	// By design this method should not be invoked from the storageQueue.
-	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
+//	NSAssert(!dispatch_get_specific(storageQueueTag), @"Invoked on incorrect queue");
 	
 	XMPPLogTrace();
 	

--- a/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.h
+++ b/Extensions/XEP-0136/CoreDataStorage/XMPPMessageArchivingCoreDataStorage.h
@@ -32,14 +32,14 @@
 + (instancetype)sharedInstance;
 
 
-@property (strong) NSString *messageEntityName;
-@property (strong) NSString *contactEntityName;
+@property (strong, atomic) NSString *messageEntityName;
+@property (strong, atomic) NSString *contactEntityName;
 
 /**
  * Defines elements within an archived message that will be tested for content presence
  * when determining whether to store the message. By default, only the body element is examined.
  */
-@property (copy, nonatomic) NSArray<NSString *> *relevantContentXPaths;
+@property (copy, atomic) NSArray<NSString *> *relevantContentXPaths;
 
 - (NSEntityDescription *)messageEntity:(NSManagedObjectContext *)moc;
 - (NSEntityDescription *)contactEntity:(NSManagedObjectContext *)moc;

--- a/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
+++ b/Extensions/XMPPMUCLight/CoreDataStorage/XMPPRoomLightCoreDataStorage.m
@@ -107,14 +107,14 @@
 
 	__block NSString *result = nil;
 	
-	dispatch_block_t block = ^{
-		result = self->messageEntityName;
-	};
-	
-	if (dispatch_get_specific(storageQueueTag))
-		block();
-	else
-		dispatch_sync(storageQueue, block);
+//	dispatch_block_t block = ^{
+//		result = self->messageEntityName;
+//	};
+//	
+//	if (dispatch_get_specific(storageQueueTag))
+//		block();
+//	else
+//		dispatch_sync(storageQueue, block);
 	
 	return result;
 }

--- a/XMPPFramework.xcodeproj/project.pbxproj
+++ b/XMPPFramework.xcodeproj/project.pbxproj
@@ -3684,7 +3684,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = XMPP;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = XMPPFramework;
 				TargetAttributes = {
 					0D44BAE91E537066000930E0 = {
@@ -3711,7 +3711,7 @@
 			};
 			buildConfigurationList = 0D44BAE41E537066000930E0 /* Build configuration list for PBXProject "XMPPFramework" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -4683,6 +4683,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -4747,6 +4748,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (iOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (macOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (tvOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFramework (tvOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (iOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (iOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (macOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (macOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (tvOS).xcscheme
+++ b/XMPPFramework.xcodeproj/xcshareddata/xcschemes/XMPPFrameworkSwift (tvOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -29,8 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -51,8 +49,6 @@
             ReferencedContainer = "container:XMPPFramework.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
This pull request changes on which thread (queue) operations using CoreData are performed. 

Instead of using a custom worker queue, operations are now performed on the private queue provided by the managed object context itself.

Note: these changes remove a lot of functionality and break some extensions!